### PR TITLE
feat: add GitHub issue creation prompt after PR sync (F2)

### DIFF
--- a/git-shipyard.sh
+++ b/git-shipyard.sh
@@ -367,6 +367,100 @@ select_issue() {
     return 0
 }
 
+# Create a GitHub issue after the sync step
+# Sets global CREATED_ISSUE_NUMBER and CREATED_ISSUE_TITLE variables
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+create_github_issue() {
+    CREATED_ISSUE_NUMBER=""
+    CREATED_ISSUE_TITLE=""
+
+    # Skip in non-interactive mode
+    if [ ! -t 0 ]; then
+        return 0
+    fi
+
+    echo ""
+    local create_issue
+    read -r -p "Create a GitHub Issue? (y/N): " create_issue
+    if [[ ! "$create_issue" =~ ^[Yy]$ ]]; then
+        return 0
+    fi
+
+    # Prompt for issue title (single-line)
+    echo ""
+    echo -e "${YELLOW}Enter issue title:${NC}"
+    local issue_title
+    read -r -p "> " issue_title
+
+    if [ -z "$issue_title" ]; then
+        echo -e "  ${YELLOW}ℹ${NC} Skipping issue creation (empty title)"
+        return 0
+    fi
+
+    # Prompt for issue body (single-line or editor, same pattern as get_commit_message)
+    echo ""
+    echo -e "${YELLOW}Enter issue body:${NC}"
+    echo -e "  ${CYAN}1)${NC} Single line (type here)"
+    echo -e "  ${CYAN}2)${NC} Multi-line (open editor)"
+    echo ""
+
+    local issue_body=""
+    local choice
+    while true; do
+        read -r -p "Choose (1/2): " choice
+        case $choice in
+            1)
+                echo ""
+                read -r -p "> " issue_body
+                break
+                ;;
+            2)
+                local editor
+                editor=$(get_editor)
+                local tmpfile
+                tmpfile=$(mktemp)
+
+                # Pre-populate editor with issue template if available
+                local template_file="$HOME/.config/issue-template.md"
+                if [ -f "$template_file" ]; then
+                    cat "$template_file" > "$tmpfile"
+                else
+                    echo -e "  ${YELLOW}⚠${NC}  Warning: No issue template found at ~/.config/issue-template.md. Using blank template."
+                    echo "" > "$tmpfile"
+                fi
+
+                echo -e "Opening editor (${editor})..."
+                $editor "$tmpfile"
+
+                # Read and clean body (remove comments and trailing whitespace)
+                issue_body=$(grep -v '^#' "$tmpfile" | sed -e 's/[[:space:]]*$//' | sed '/^$/N;/^\n$/d')
+                rm -f "$tmpfile"
+                break
+                ;;
+            *)
+                echo -e "${RED}Invalid choice. Enter 1 or 2.${NC}"
+                ;;
+        esac
+    done
+
+    # Create the issue
+    echo ""
+    echo -e "${BLUE}Creating GitHub issue...${NC}"
+    local issue_output
+    if ! issue_output=$(gh issue create --title "$issue_title" --body "$issue_body" 2>&1); then
+        echo -e "  ${RED}✗${NC} Failed to create issue"
+        echo "$issue_output" >&2
+        return 1
+    fi
+
+    # Extract issue number from the returned URL (e.g. https://github.com/owner/repo/issues/42)
+    CREATED_ISSUE_NUMBER=$(echo "$issue_output" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+')
+    CREATED_ISSUE_TITLE="$issue_title"
+    echo -e "  ${GREEN}✓${NC} Issue #${CREATED_ISSUE_NUMBER} created: ${CREATED_ISSUE_TITLE}"
+    return 0
+}
+
 # Main script
 main() {
     # Trap for unexpected errors (inside main for source guard compatibility)
@@ -574,8 +668,12 @@ Closes #${SELECTED_ISSUE}"
     
     echo -e "${YELLOW}─────────────────────────────────────────${NC}"
     echo ""
-    
+
+    # Offer to create a new GitHub issue
+    create_github_issue || true
+
     # Success message
+    echo ""
     echo -e "${GREEN}╔════════════════════════════════════════╗${NC}"
     echo -e "${GREEN}║     ✓ All actions completed!           ║${NC}"
     echo -e "${GREEN}╚════════════════════════════════════════╝${NC}"
@@ -588,6 +686,9 @@ Closes #${SELECTED_ISSUE}"
     echo -e "  • Pull request created (${HEAD_BRANCH} → ${BASE_BRANCH})"
     if [ -n "$SELECTED_ISSUE" ]; then
         echo -e "  • Linked to issue #${SELECTED_ISSUE} (closes on merge)"
+    fi
+    if [ -n "$CREATED_ISSUE_NUMBER" ]; then
+        echo -e "  • Created issue #${CREATED_ISSUE_NUMBER}: ${CREATED_ISSUE_TITLE}"
     fi
     echo ""
     echo -e "${YELLOW}Goodbye!${NC}"

--- a/logs/.008321ea3ac825c8f9de32021c40fb0e6626377d-audit.json
+++ b/logs/.008321ea3ac825c8f9de32021c40fb0e6626377d-audit.json
@@ -9,6 +9,11 @@
             "date": 1771127354165,
             "name": "/home/scotton/dev/projects/git_shipyard/logs/mcp-puppeteer-2026-02-14.log",
             "hash": "7d3e20d95ce9b624fbb7e2a64c50b320e2407e04180ca01b7986009373756474"
+        },
+        {
+            "date": 1771715477621,
+            "name": "/home/scotton/dev/projects/git_shipyard/logs/mcp-puppeteer-2026-02-21.log",
+            "hash": "7f52a2b29980a922ebd49d926f75387399ab6891a54fe2e0d368842accc0b025"
         }
     ],
     "hashType": "sha256"

--- a/logs/mcp-puppeteer-2026-02-21.log
+++ b/logs/mcp-puppeteer-2026-02-21.log
@@ -1,0 +1,2 @@
+{"level":"info","message":"Starting MCP server","service":"mcp-puppeteer","timestamp":"2026-02-21 17:11:17.660"}
+{"level":"info","message":"MCP server started successfully","service":"mcp-puppeteer","timestamp":"2026-02-21 17:11:17.661"}

--- a/test/git-shipyard.bats
+++ b/test/git-shipyard.bats
@@ -686,3 +686,305 @@ EOF
     run grep "Multi-line (open editor)" "$SCRIPT_DIR/git-shipyard.sh"
     [ "$status" -eq 0 ]
 }
+
+# =============================================================================
+# Test 13: create_github_issue() function
+# =============================================================================
+
+@test "create_github_issue skips in non-interactive mode" {
+    cat > "$TEST_DIR/test_issue_noninteractive.sh" << EOF
+#!/usr/bin/env bash
+main() { :; }
+source "$SCRIPT_DIR/git-shipyard.sh"
+create_github_issue
+echo "STATUS=\$?"
+echo "NUMBER=\$CREATED_ISSUE_NUMBER"
+EOF
+    chmod +x "$TEST_DIR/test_issue_noninteractive.sh"
+
+    # Pipe input to simulate non-interactive mode (stdin is not a terminal)
+    run bash -c "echo '' | $TEST_DIR/test_issue_noninteractive.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NUMBER="* ]]
+    # Should NOT contain any prompts
+    [[ "$output" != *"Create a GitHub Issue"* ]]
+}
+
+@test "create_github_issue skips when user declines" {
+    cat > "$TEST_DIR/test_issue_decline.sh" << 'EOF'
+#!/usr/bin/env bash
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+
+# Simulate interactive terminal
+create_github_issue() {
+    CREATED_ISSUE_NUMBER=""
+    CREATED_ISSUE_TITLE=""
+
+    local create_issue="n"
+    if [[ ! "$create_issue" =~ ^[Yy]$ ]]; then
+        echo "SKIPPED"
+        return 0
+    fi
+}
+
+create_github_issue
+echo "NUMBER=$CREATED_ISSUE_NUMBER"
+EOF
+    chmod +x "$TEST_DIR/test_issue_decline.sh"
+
+    run "$TEST_DIR/test_issue_decline.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SKIPPED"* ]]
+    [[ "$output" == *"NUMBER="* ]]
+}
+
+@test "create_github_issue skips on empty title" {
+    cat > "$TEST_DIR/test_issue_empty_title.sh" << 'EOF'
+#!/usr/bin/env bash
+YELLOW='\033[1;33m'
+NC='\033[0m'
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+
+# Simulate the empty title path
+issue_title=""
+if [ -z "$issue_title" ]; then
+    echo -e "  ${YELLOW}ℹ${NC} Skipping issue creation (empty title)"
+    echo "EMPTY_TITLE_HANDLED"
+fi
+echo "NUMBER=$CREATED_ISSUE_NUMBER"
+EOF
+    chmod +x "$TEST_DIR/test_issue_empty_title.sh"
+
+    run "$TEST_DIR/test_issue_empty_title.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Skipping issue creation (empty title)"* ]]
+    [[ "$output" == *"EMPTY_TITLE_HANDLED"* ]]
+}
+
+@test "create_github_issue creates issue successfully (mocked)" {
+    cat > "$TEST_DIR/test_issue_success.sh" << 'EOF'
+#!/usr/bin/env bash
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+
+# Mock gh to return a GitHub issue URL
+gh() {
+    echo "https://github.com/owner/repo/issues/42"
+    return 0
+}
+
+issue_title="Fix the login bug"
+issue_body="Users cannot log in when using SSO"
+
+echo -e "${BLUE}Creating GitHub issue...${NC}"
+local_output=$(gh issue create --title "$issue_title" --body "$issue_body" 2>&1)
+CREATED_ISSUE_NUMBER=$(echo "$local_output" | grep -oE '[0-9]+$')
+CREATED_ISSUE_TITLE="$issue_title"
+echo -e "  ${GREEN}✓${NC} Issue #${CREATED_ISSUE_NUMBER} created: ${CREATED_ISSUE_TITLE}"
+echo "NUMBER=$CREATED_ISSUE_NUMBER"
+echo "TITLE=$CREATED_ISSUE_TITLE"
+EOF
+    chmod +x "$TEST_DIR/test_issue_success.sh"
+
+    run "$TEST_DIR/test_issue_success.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Issue #42 created: Fix the login bug"* ]]
+    [[ "$output" == *"NUMBER=42"* ]]
+    [[ "$output" == *"TITLE=Fix the login bug"* ]]
+}
+
+@test "create_github_issue handles gh failure" {
+    cat > "$TEST_DIR/test_issue_fail.sh" << 'EOF'
+#!/usr/bin/env bash
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+
+# Mock gh to fail
+gh() {
+    echo "HTTP 422: Validation Failed" >&2
+    return 1
+}
+
+issue_title="Fix the login bug"
+issue_body="Description"
+
+echo -e "${BLUE}Creating GitHub issue...${NC}"
+if ! issue_output=$(gh issue create --title "$issue_title" --body "$issue_body" 2>&1); then
+    echo -e "  ${RED}✗${NC} Failed to create issue"
+    echo "$issue_output" >&2
+    echo "FAILED"
+    exit 1
+fi
+EOF
+    chmod +x "$TEST_DIR/test_issue_fail.sh"
+
+    run "$TEST_DIR/test_issue_fail.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Failed to create issue"* ]]
+    [[ "$output" == *"FAILED"* ]]
+}
+
+@test "create_github_issue extracts issue number from URL" {
+    cat > "$TEST_DIR/test_issue_extract.sh" << 'EOF'
+#!/usr/bin/env bash
+# Test various URL formats that gh might return
+urls=(
+    "https://github.com/owner/repo/issues/1"
+    "https://github.com/owner/repo/issues/42"
+    "https://github.com/owner/repo/issues/999"
+)
+
+for url in "${urls[@]}"; do
+    number=$(echo "$url" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+')
+    echo "URL=$url NUMBER=$number"
+done
+EOF
+    chmod +x "$TEST_DIR/test_issue_extract.sh"
+
+    run "$TEST_DIR/test_issue_extract.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NUMBER=1"* ]]
+    [[ "$output" == *"NUMBER=42"* ]]
+    [[ "$output" == *"NUMBER=999"* ]]
+}
+
+@test "create_github_issue extraction ignores trailing non-URL text" {
+    cat > "$TEST_DIR/test_issue_extract_robust.sh" << 'EOF'
+#!/usr/bin/env bash
+# Simulate gh outputting extra text after the URL
+output="https://github.com/owner/repo/issues/15
+Some deprecation warning 2025"
+
+number=$(echo "$output" | grep -oE '/issues/[0-9]+' | grep -oE '[0-9]+')
+echo "NUMBER=$number"
+EOF
+    chmod +x "$TEST_DIR/test_issue_extract_robust.sh"
+
+    run "$TEST_DIR/test_issue_extract_robust.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NUMBER=15"* ]]
+}
+
+@test "create_github_issue editor mode uses template when available" {
+    cat > "$TEST_DIR/test_issue_template.sh" << 'EOF'
+#!/usr/bin/env bash
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# Create a fake template
+template_dir="$TEST_DIR/fake_home/.config"
+mkdir -p "$template_dir"
+echo "## Bug Report" > "$template_dir/issue-template.md"
+echo "Steps to reproduce:" >> "$template_dir/issue-template.md"
+
+template_file="$template_dir/issue-template.md"
+tmpfile=$(mktemp)
+
+if [ -f "$template_file" ]; then
+    cat "$template_file" > "$tmpfile"
+    echo "TEMPLATE_LOADED"
+else
+    echo "TEMPLATE_MISSING"
+fi
+
+# Verify template content was copied
+content=$(cat "$tmpfile")
+rm -f "$tmpfile"
+
+echo "CONTENT=$content"
+EOF
+    chmod +x "$TEST_DIR/test_issue_template.sh"
+
+    run "$TEST_DIR/test_issue_template.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TEMPLATE_LOADED"* ]]
+    [[ "$output" == *"Bug Report"* ]]
+}
+
+@test "create_github_issue editor mode warns when template missing" {
+    cat > "$TEST_DIR/test_issue_no_template.sh" << 'EOF'
+#!/usr/bin/env bash
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+template_file="/nonexistent/path/issue-template.md"
+tmpfile=$(mktemp)
+
+if [ -f "$template_file" ]; then
+    cat "$template_file" > "$tmpfile"
+    echo "TEMPLATE_LOADED"
+else
+    echo -e "  ${YELLOW}⚠${NC}  Warning: No issue template found at ~/.config/issue-template.md. Using blank template."
+    echo "" > "$tmpfile"
+    echo "TEMPLATE_MISSING"
+fi
+
+rm -f "$tmpfile"
+EOF
+    chmod +x "$TEST_DIR/test_issue_no_template.sh"
+
+    run "$TEST_DIR/test_issue_no_template.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"TEMPLATE_MISSING"* ]]
+    [[ "$output" == *"Warning: No issue template found"* ]]
+}
+
+@test "summary shows created issue when CREATED_ISSUE_NUMBER is set" {
+    cat > "$TEST_DIR/test_issue_summary.sh" << 'EOF'
+#!/usr/bin/env bash
+CYAN='\033[0;36m'
+NC='\033[0m'
+CREATED_ISSUE_NUMBER="42"
+CREATED_ISSUE_TITLE="Fix the login bug"
+
+# Simulate the summary section from main()
+if [ -n "$CREATED_ISSUE_NUMBER" ]; then
+    echo -e "  • Created issue #${CREATED_ISSUE_NUMBER}: ${CREATED_ISSUE_TITLE}"
+fi
+EOF
+    chmod +x "$TEST_DIR/test_issue_summary.sh"
+
+    run "$TEST_DIR/test_issue_summary.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Created issue #42: Fix the login bug"* ]]
+}
+
+@test "summary omits issue line when no issue was created" {
+    cat > "$TEST_DIR/test_issue_no_summary.sh" << 'EOF'
+#!/usr/bin/env bash
+CREATED_ISSUE_NUMBER=""
+CREATED_ISSUE_TITLE=""
+
+# Simulate the summary section from main()
+echo "START_SUMMARY"
+if [ -n "$CREATED_ISSUE_NUMBER" ]; then
+    echo -e "  • Created issue #${CREATED_ISSUE_NUMBER}: ${CREATED_ISSUE_TITLE}"
+fi
+echo "END_SUMMARY"
+EOF
+    chmod +x "$TEST_DIR/test_issue_no_summary.sh"
+
+    run "$TEST_DIR/test_issue_no_summary.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"START_SUMMARY"* ]]
+    [[ "$output" == *"END_SUMMARY"* ]]
+    [[ "$output" != *"Created issue"* ]]
+}
+
+@test "create_github_issue function exists in script" {
+    run grep "create_github_issue()" "$SCRIPT_DIR/git-shipyard.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "create_github_issue is called in main with || true" {
+    run grep "create_github_issue || true" "$SCRIPT_DIR/git-shipyard.sh"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
feat: add GitHub issue creation prompt after PR sync (F2)

Add optional create_github_issue() function that runs after the PR
creation step. Prompts the user to create a new GitHub issue with:

- Single-line title input
- Single-line or editor-based body input (mirrors get_commit_message pattern)
- Editor pre-populated from ~/.config/issue-template.md with a warning
  fallback if the template file is missing
- Issue created via `gh issue create` with success confirmation
- Created issue number and title reflected in the final summary

Closes #9

Closes #9

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added optional GitHub issue creation prompt after PR sync that allows users to create issues with customizable title and body input (single-line or editor mode with template support).

**Key Changes:**
- Added `create_github_issue()` function with interactive prompts mirroring `get_commit_message()` pattern
- Editor mode pre-populates from `~/.config/issue-template.md` with warning if template missing
- Issue created via `gh issue create` with success confirmation and number extraction
- Global variables `CREATED_ISSUE_NUMBER` and `CREATED_ISSUE_TITLE` track created issue for final summary
- Called from `main()` after PR creation with `|| true` to prevent failure interruption
- Comprehensive test coverage with 13 BATS test cases

**Issues Found:**
- Unquoted editor variable expansion on line 434 could fail if editor path contains spaces (matches pre-existing pattern in codebase but should be fixed)

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor shell quoting fix needed for editor paths containing spaces
- Implementation follows established codebase patterns and includes comprehensive test coverage (13 test cases). The only issue is an unquoted variable expansion that matches a pre-existing pattern but should still be fixed. Feature is non-critical (optional prompt) and fails gracefully with `|| true`.
- git-shipyard.sh:434 needs editor variable quoting fix

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| git-shipyard.sh | Added `create_github_issue()` function with interactive prompts for title/body input, editor template support, and issue creation via gh CLI. Found one critical shell quoting issue with editor invocation. |
| test/git-shipyard.bats | Added comprehensive test coverage for `create_github_issue()` with 13 test cases covering non-interactive mode, user decline, empty title, success/failure scenarios, URL extraction, and template handling. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([PR Sync Complete]) --> Prompt{Create GitHub Issue?}
    Prompt -->|No/N| Skip[Skip issue creation]
    Prompt -->|Yes/Y| TitlePrompt[Prompt for issue title]
    TitlePrompt --> TitleCheck{Title empty?}
    TitleCheck -->|Yes| Skip
    TitleCheck -->|No| BodyChoice{Body input method?}
    BodyChoice -->|1: Single line| SingleLine[Read single-line input]
    BodyChoice -->|2: Editor| CheckTemplate{Template exists?}
    CheckTemplate -->|Yes| LoadTemplate[Load template file]
    CheckTemplate -->|No| Warn[Show warning + blank template]
    LoadTemplate --> OpenEditor[Open editor]
    Warn --> OpenEditor
    OpenEditor --> CleanBody[Remove comments & whitespace]
    SingleLine --> CreateIssue[gh issue create]
    CleanBody --> CreateIssue
    CreateIssue --> Result{Success?}
    Result -->|Yes| Extract[Extract issue number from URL]
    Result -->|No| Error[Show error message]
    Extract --> Summary[Add to final summary]
    Error --> End([Exit with return 1])
    Skip --> End2([Exit with return 0])
    Summary --> End2
```

<sub>Last reviewed commit: d75b29f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->