### PR TITLE
feat: implement pre-PR conflict resolution sync step (F4) (#11)

### DIFF
--- a/git-shipyard.sh
+++ b/git-shipyard.sh
@@ -15,7 +15,7 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --base)
             if [ -z "$2" ] || [[ "$2" == --* ]]; then
-                echo "Error: --base requires a branch name"
+                echo "Error: Missing value for --base"
                 exit 1
             fi
             BASE_BRANCH="$2"
@@ -23,7 +23,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --head)
             if [ -z "$2" ] || [[ "$2" == --* ]]; then
-                echo "Error: --head requires a branch name"
+                echo "Error: Missing value for --head"
                 exit 1
             fi
             HEAD_BRANCH="$2"
@@ -607,6 +607,9 @@ pr_management_mode() {
     echo -e "  2. Delete remote branch (--delete-branch)"
     echo -e "  3. Switch to ${BASE_BRANCH} and pull latest"
     echo -e "  4. Delete local head branch"
+    echo ""
+    echo -e "  ${YELLOW}⚠${NC}  Note: Squash-merge does not record merge history."
+    echo -e "       If you keep the branch and merge again, duplicate conflicts may arise."
     echo ""
 
     read -r -p "Proceed? (y/N): " confirm

--- a/test/git-shipyard.bats
+++ b/test/git-shipyard.bats
@@ -572,13 +572,16 @@ EOF
 # Test 8: Conflict handling uses git reset --merge
 # =============================================================================
 
-@test "conflict abort uses git reset --merge not git merge --abort" {
-    # Verify the script uses correct abort command for squash merge
-    run grep -c "git reset --merge" "$SCRIPT_DIR/git-shipyard.sh"
+@test "squash-merge uses gh pr merge not local git merge --squash" {
+    # Script delegates squash-merge to the GitHub API via gh pr merge
+    run grep "gh pr merge.*--squash" "$SCRIPT_DIR/git-shipyard.sh"
     [ "$status" -eq 0 ]
-    [ "$output" -ge 1 ]
-    
-    # Should NOT use git merge --abort for squash conflicts
+
+    # Should NOT use local git merge --squash (which would require git reset --merge on conflict)
+    run grep -c "git merge --squash" "$SCRIPT_DIR/git-shipyard.sh"
+    [ "$output" -eq 0 ]
+
+    # Should NOT use git merge --abort (not valid after git merge --squash)
     run grep -c "git merge --abort" "$SCRIPT_DIR/git-shipyard.sh"
     [ "$output" -eq 0 ]
 }
@@ -606,8 +609,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "script deletes remote branch with --delete flag" {
-    run grep "git push origin --delete" "$SCRIPT_DIR/git-shipyard.sh"
+@test "script deletes remote branch via gh pr merge --delete-branch" {
+    run grep "gh pr merge.*--delete-branch" "$SCRIPT_DIR/git-shipyard.sh"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
feat: implement pre-PR conflict resolution sync step (F4) (#11)

Add sync_with_base() to fetch and merge BASE_BRANCH into HEAD_BRANCH
immediately before PR creation in Full Mode and PR-Only Mode. Detects
merge conflicts, lists conflicting files, and halts with resolution
instructions. On clean merge, displays success and continues to PR
creation. Add check_merge_in_progress() to intercept a leftover
MERGE_HEAD state on re-run after conflict resolution, completing the
merge commit automatically.

Add BATS test coverage (Tests 15–16): clean merge, fetch-fail graceful
skip, conflict exit with file listing, resolution instructions,
call-order assertions, and MERGE_HEAD resumption scenarios.

Fix pre-existing test failures to align with current implementation:
- Standardise --base/--head missing-value error messages
- Add squash-merge history/duplicate-conflicts warning to
  pr_management_mode confirmation
- Update stale squash-merge tests to reflect GitHub API approach
  (gh pr merge --squash --delete-branch) instead of local git merge

Closes #12

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added pre-PR conflict resolution with `sync_with_base()` and `check_merge_in_progress()` functions to merge BASE_BRANCH into HEAD_BRANCH before PR creation, detecting conflicts and providing resolution instructions.

**Key changes:**
- `sync_with_base()` fetches and merges `origin/BASE_BRANCH` into `HEAD_BRANCH` before PR creation
- `check_merge_in_progress()` detects leftover MERGE_HEAD state and auto-completes resolved merges
- Updated confirmation messages to show sync step in workflow (step 4 in full mode, step 2 in PR-only mode)
- Fixed pre-existing test failures: standardized `--base`/`--head` error messages, added squash-merge warnings, updated tests to reflect GitHub API approach

**Critical issue found:**
- Merge commits created by both `sync_with_base()` and `check_merge_in_progress()` are not pushed to remote before PR creation, so the PR won't include the sync changes

<h3>Confidence Score: 2/5</h3>

- This PR has a critical logic bug that will cause the sync feature to malfunction
- The implementation adds the intended sync functionality, but merge commits are never pushed to the remote repository before PR creation. This means the PR will be out of sync with the local branch, defeating the purpose of the sync step. The bug affects both `sync_with_base()` and `check_merge_in_progress()` functions.
- Pay close attention to `git-shipyard.sh` - both `sync_with_base()` and `check_merge_in_progress()` need to push merge commits to remote after creating them

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| git-shipyard.sh | Added `sync_with_base()` and `check_merge_in_progress()` functions for pre-PR conflict resolution, but merge commits are not pushed to remote before PR creation (critical logic bug) |
| test/git-shipyard.bats | Updated tests to align with current implementation: standardized error messages, added squash-merge warnings, updated to reflect GitHub API approach instead of local git merge |

</details>


</details>


<sub>Last reviewed commit: 41b88c2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->