### PR TITLE
dev

### DIFF
--- a/git-shipyard.sh
+++ b/git-shipyard.sh
@@ -495,6 +495,13 @@ check_merge_in_progress() {
         error_exit "Failed to complete merge commit."
     fi
     echo -e "  ${GREEN}✓${NC} Merge committed — ${HEAD_BRANCH} is up to date with ${BASE_BRANCH}"
+
+    # Push the merge commit so it reaches the remote before PR creation
+    echo -e "${BLUE}Pushing merge commit to origin/${HEAD_BRANCH}...${NC}"
+    if ! git push origin "${HEAD_BRANCH}" 2>/dev/null; then
+        error_exit "Failed to push merge commit to remote."
+    fi
+    echo -e "  ${GREEN}✓${NC} Merge commit pushed to remote"
     echo ""
 }
 
@@ -541,9 +548,16 @@ sync_with_base() {
     fi
 
     echo -e "  ${GREEN}✓${NC} ${HEAD_BRANCH} is up to date with ${BASE_BRANCH}"
+
+    # Push the merge commit to remote so the PR includes the sync changes
+    echo -e "${BLUE}Pushing merge commit to origin/${HEAD_BRANCH}...${NC}"
+    if ! git push origin "${HEAD_BRANCH}" 2>/dev/null; then
+        error_exit "Failed to push merge commit to remote."
+    fi
+    echo -e "  ${GREEN}✓${NC} Merge commit pushed to remote"
 }
 
-# PR Management Mode: list open PRs and let user squash-merge one
+# PR Management Mode:
 pr_management_mode() {
     echo ""
     echo -e "${BLUE}Fetching open pull requests...${NC}"

--- a/test/git-shipyard.bats
+++ b/test/git-shipyard.bats
@@ -1492,6 +1492,40 @@ EOF
     [[ "$output" == *"Re-run git-shipyard"* ]] || [[ "$output" == *"re-run"* ]]
 }
 
+@test "sync_with_base pushes merge commit after clean merge" {
+    cat > "$TEST_DIR/test_sync_push.sh" << EOF
+#!/usr/bin/env bash
+BLUE='\\033[0;34m'
+GREEN='\\033[0;32m'
+YELLOW='\\033[1;33m'
+RED='\\033[0;31m'
+NC='\\033[0m'
+BASE_BRANCH="main"
+HEAD_BRANCH="dev"
+
+error_exit() { echo "Error: \$1" >&2; exit 1; }
+
+# Mock git: fetch succeeds, not ancestor, merge succeeds, push succeeds
+git() {
+    if [ "\$1" = "fetch" ]; then return 0; fi
+    if [ "\$1" = "merge-base" ] && [ "\$2" = "--is-ancestor" ]; then return 1; fi
+    if [ "\$1" = "merge" ]; then return 0; fi
+    if [ "\$1" = "push" ]; then echo "PUSHED"; return 0; fi
+    /usr/bin/git "\$@"
+}
+export -f git
+
+source "$SCRIPT_DIR/git-shipyard.sh"
+sync_with_base
+EOF
+    chmod +x "$TEST_DIR/test_sync_push.sh"
+
+    run "$TEST_DIR/test_sync_push.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PUSHED"* ]]
+    [[ "$output" == *"Merge commit pushed to remote"* ]]
+}
+
 @test "sync_with_base is called after push in main" {
     # Verify sync_with_base call appears after the git push commands
     local push_line sync_line


### PR DESCRIPTION
- **feat: implement pre-PR conflict resolution sync step (F4) (#11)**
- **fix: push sync merge commit to remote before PR creation**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR builds on feature F4 (pre-PR conflict resolution) by ensuring merge commits are pushed to the remote before PR creation. Two changes were made:

1. **`check_merge_in_progress()` (git-shipyard.sh:499-504)**: Added push after completing a merge commit from conflict resolution resumption
2. **`sync_with_base()` (git-shipyard.sh:552-557)**: Added push after merging base branch into head branch

Both functions now follow the pattern: merge → commit → push → continue to PR creation. This ensures the PR includes the sync changes and prevents GitHub from showing the head branch as behind the base.

**Key Changes:**
- Added `git push origin ${HEAD_BRANCH}` after merge commits in both sync functions
- Added test coverage for `sync_with_base` push behavior
- Minor documentation update (removed "list open PRs and let user squash-merge one" comment fragment)

The changes are straightforward and align with the existing code style. The push operations use `error_exit` on failure, consistent with the project's error handling approach.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor considerations for test coverage
- The implementation correctly addresses the stated problem (pushing merge commits before PR creation) with appropriate error handling. The code follows existing patterns and style guidelines. Score is 4 (not 5) due to incomplete test coverage - only `sync_with_base` push behavior is tested, while `check_merge_in_progress` push behavior lacks corresponding tests
- test/git-shipyard.bats could benefit from additional test coverage for the `check_merge_in_progress` push scenario

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| git-shipyard.sh | Adds `git push` after merge commits in `check_merge_in_progress()` and `sync_with_base()` to ensure sync changes reach remote before PR creation |
| test/git-shipyard.bats | Adds test coverage for new push behavior in `sync_with_base()` function after clean merge |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start([Script Start]) --> PreFlight[Pre-flight Checks]
    PreFlight --> CheckMerge[check_merge_in_progress]
    
    CheckMerge --> HasMergeHead{MERGE_HEAD<br/>exists?}
    HasMergeHead -->|No| ModeDetect[Mode Detection]
    HasMergeHead -->|Yes| CheckConflicts{Unresolved<br/>conflicts?}
    
    CheckConflicts -->|Yes| Error1([Exit: Resolve conflicts])
    CheckConflicts -->|No| CommitMerge[git commit --no-edit]
    CommitMerge --> PushMerge1[**NEW: git push origin HEAD**]
    PushMerge1 --> ModeDetect
    
    ModeDetect --> Workflow[Full/PR-Only Mode Workflow]
    Workflow --> MainPush[git push origin HEAD]
    MainPush --> SyncBase[sync_with_base]
    
    SyncBase --> Fetch[git fetch origin BASE]
    Fetch --> IsAncestor{Already<br/>up to date?}
    IsAncestor -->|Yes| CreatePR[Create Pull Request]
    IsAncestor -->|No| Merge[git merge origin/BASE]
    
    Merge --> MergeOK{Success?}
    MergeOK -->|No| Error2([Exit: Resolve conflicts])
    MergeOK -->|Yes| PushMerge2[**NEW: git push origin HEAD**]
    PushMerge2 --> CreatePR
    
    style PushMerge1 fill:#90EE90
    style PushMerge2 fill:#90EE90
```

<sub>Last reviewed commit: e9c7029</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->