### PR TITLE
Bug: Display completed actions to user.

### DIFF
--- a/git-shipyard.sh
+++ b/git-shipyard.sh
@@ -507,19 +507,24 @@ check_merge_in_progress() {
 
 # Sync HEAD_BRANCH with BASE_BRANCH before creating a PR
 # Fetches latest base, merges it in; on conflict lists files and exits with instructions
+# Sets global SYNC_RESULT for summary display: "synced", "up_to_date", or "skipped"
+SYNC_RESULT=""
 sync_with_base() {
+    SYNC_RESULT=""
     echo ""
     echo -e "${BLUE}Syncing ${HEAD_BRANCH} with ${BASE_BRANCH} before PR...${NC}"
 
     # Fetch latest base branch from remote
     if ! git fetch origin "${BASE_BRANCH}" 2>/dev/null; then
         echo -e "  ${YELLOW}⚠${NC}  Could not fetch ${BASE_BRANCH} — skipping sync"
+        SYNC_RESULT="skipped"
         return 0
     fi
 
     # Check if head already contains all base commits (already up to date)
     if git merge-base --is-ancestor "origin/${BASE_BRANCH}" HEAD 2>/dev/null; then
         echo -e "  ${GREEN}✓${NC} ${HEAD_BRANCH} is up to date with ${BASE_BRANCH}"
+        SYNC_RESULT="up_to_date"
         return 0
     fi
 
@@ -555,6 +560,7 @@ sync_with_base() {
         error_exit "Failed to push merge commit to remote."
     fi
     echo -e "  ${GREEN}✓${NC} Merge commit pushed to remote"
+    SYNC_RESULT="synced"
 }
 
 # PR Management Mode:
@@ -934,6 +940,11 @@ Closes #${SELECTED_ISSUE}"
         echo -e "  • Changes staged and committed"
     fi
     echo -e "  • Pushed to origin/${HEAD_BRANCH}"
+    if [ "$SYNC_RESULT" = "synced" ]; then
+        echo -e "  • Synced ${HEAD_BRANCH} with ${BASE_BRANCH} (merged new changes)"
+    elif [ "$SYNC_RESULT" = "up_to_date" ]; then
+        echo -e "  • Synced ${HEAD_BRANCH} with ${BASE_BRANCH} (already up to date)"
+    fi
     echo -e "  • Pull request created (${HEAD_BRANCH} → ${BASE_BRANCH})"
     if [ -n "$SELECTED_ISSUE" ]; then
         echo -e "  • Linked to issue #${SELECTED_ISSUE} (closes on merge)"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added user-facing feedback for the sync operation that occurs before PR creation. The `sync_with_base()` function now sets a global `SYNC_RESULT` variable to track whether the sync merged new changes, was already up to date, or was skipped. This status is displayed in the completion summary, giving users visibility into what happened during the sync step.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are straightforward and well-contained: adds a global variable to track sync status and conditionally displays it in the summary. The variable is properly initialized at both the global scope and function entry, and all three code paths in `sync_with_base()` set appropriate values. No logic errors or edge cases identified.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| git-shipyard.sh | Added sync status tracking to display sync results in completion summary |

</details>


</details>


<sub>Last reviewed commit: 7a967a6</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->